### PR TITLE
TokenBackend: handle request input parameter

### DIFF
--- a/django_token/backends.py
+++ b/django_token/backends.py
@@ -6,7 +6,7 @@ User = get_user_model()
 
 
 class TokenBackend(object):
-    def authenticate(self, token=None):
+    def authenticate(self, request, token=None, **kwargs):
         """
         Try to find a user with the given token
         """

--- a/django_token/models.py
+++ b/django_token/models.py
@@ -11,7 +11,7 @@ class Token(models.Model):
     An access token that is associated with a user.  This is essentially the same as the token model from Django REST Framework
     """
     key = models.CharField(max_length=40, primary_key=True)
-    user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name="token")
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name="token", on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
The `TokenBackend` did not cater for a request input parameter, which caused `django.contrib.auth.authenticate` to skip the backend.